### PR TITLE
Output directory

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -1,6 +1,6 @@
 subprojects {
 	group = 'io.opencaesar.owl'
-	version = '0.9.14'
+	version = '0.9.15'
 	
 	ext.versions = [
 		owl: '5.1.17',

--- a/owl-query-gradle/src/main/java/io/opencaesar/owl/query/OwlQueryTask.java
+++ b/owl-query-gradle/src/main/java/io/opencaesar/owl/query/OwlQueryTask.java
@@ -14,6 +14,7 @@ import org.apache.log4j.xml.DOMConfigurator;
 import org.gradle.api.DefaultTask;
 import org.gradle.api.GradleException;
 import org.gradle.api.file.ConfigurableFileCollection;
+import org.gradle.api.file.DirectoryProperty;
 import org.gradle.api.file.RegularFileProperty;
 import org.gradle.api.provider.Property;
 import org.gradle.api.tasks.Input;
@@ -66,7 +67,7 @@ public abstract class OwlQueryTask extends DefaultTask {
 	protected abstract ConfigurableFileCollection getInputFiles();
 
 	@OutputDirectory
-	public abstract RegularFileProperty getResultPath();
+	public abstract DirectoryProperty getResultPath();
 
 	@Input
 	@Optional

--- a/owl-query-gradle/src/main/java/io/opencaesar/owl/query/OwlQueryTask.java
+++ b/owl-query-gradle/src/main/java/io/opencaesar/owl/query/OwlQueryTask.java
@@ -42,7 +42,6 @@ public abstract class OwlQueryTask extends DefaultTask {
     // contributes to the input files
 	public File queryPath;
 
-	@SuppressWarnings({ "unused", "deprecation" })
 	public void setQueryPath(File path) throws IOException {
 		queryPath = path;
 		final List<File> files = new ArrayList<>();

--- a/owl-query-gradle/src/main/java/io/opencaesar/owl/query/OwlQueryTask.java
+++ b/owl-query-gradle/src/main/java/io/opencaesar/owl/query/OwlQueryTask.java
@@ -85,7 +85,8 @@ public abstract class OwlQueryTask extends DefaultTask {
 			Path outputFolder = resultPath.toPath();
 			inputFiles.forEach(f -> {
 				String ifn = f.getName();
-				String ofn = ifn.substring(0, ifn.length() - 6) + format;
+				int i = ifn.lastIndexOf('.');
+				String ofn = ((i> 0) ? ifn.substring(0, i+1) : ifn+'.') + format;
 				outputFiles.add(outputFolder.resolve(ofn).toFile());
 			});
 			getOutputFiles().setFrom(outputFiles);

--- a/owl-query-gradle/src/main/java/io/opencaesar/owl/query/OwlQueryTask.java
+++ b/owl-query-gradle/src/main/java/io/opencaesar/owl/query/OwlQueryTask.java
@@ -9,19 +9,11 @@ import java.nio.file.Path;
 import java.util.ArrayList;
 import java.util.List;
 
-import org.apache.log4j.Logger;
-import org.apache.log4j.xml.DOMConfigurator;
 import org.gradle.api.DefaultTask;
 import org.gradle.api.GradleException;
 import org.gradle.api.file.ConfigurableFileCollection;
-import org.gradle.api.file.DirectoryProperty;
-import org.gradle.api.file.RegularFileProperty;
 import org.gradle.api.provider.Property;
-import org.gradle.api.tasks.Input;
-import org.gradle.api.tasks.InputFiles;
-import org.gradle.api.tasks.Optional;
-import org.gradle.api.tasks.OutputDirectory;
-import org.gradle.api.tasks.TaskAction;
+import org.gradle.api.tasks.*;
 import org.gradle.work.Incremental;
 
 /**
@@ -30,47 +22,76 @@ import org.gradle.work.Incremental;
  */
 public abstract class OwlQueryTask extends DefaultTask {
 
-	private final static Logger LOGGER = Logger.getLogger(OwlQueryTask.class);
-
-	static {
-		DOMConfigurator.configure(ClassLoader.getSystemClassLoader().getResource("owlquery.log4j2.properties"));
-	}
-
 	@Input
 	public abstract Property<String> getEndpointURL();
 
-    // contributes to the input files
-	public File queryPath;
+	private File queryPath;
+
+	@Input
+	public File getQueryPath() { return queryPath; }
 
 	public void setQueryPath(File path) throws IOException {
 		queryPath = path;
-		final List<File> files = new ArrayList<>();
-		if (null == queryPath || !queryPath.exists() || !queryPath.canRead())
-			LOGGER.warn("OwlQuery("+getName()+"): queryPath is not an existing, readable input file or directory got: " + path);
-		else if (queryPath.isFile())
-			files.add(queryPath);
-		else
-			// See https://docs.oracle.com/javase/8/docs/api/java/nio/file/DirectoryStream.html
-			try (DirectoryStream<Path> stream = Files.newDirectoryStream(path.toPath(), "*.sparql")) {
-				for (Path entry : stream) {
-					files.add(entry.toFile());
-				}
-			} catch (DirectoryIteratorException ex) {
-				throw ex.getCause();
-			}
-		getInputFiles().setFrom(files);
+		calculateInputOutputFiles();
+	}
+
+	private File resultPath;
+
+	@Internal
+	public File getResultPath() { return resultPath; }
+
+	@SuppressWarnings("unused")
+	public void setResultPath(File p) throws IOException {
+		resultPath = p;
+		calculateInputOutputFiles();
+	}
+
+	private String format = OwlQueryApp.DEFAULT_FORMAT;
+
+	@Input
+	@Optional
+	public String getFormat() { return format; }
+
+	public void setFormat(String f) throws IOException {
+		format=f;
+		calculateInputOutputFiles();
 	}
 
 	@Incremental
 	@InputFiles
 	protected abstract ConfigurableFileCollection getInputFiles();
 
-	@OutputDirectory
-	public abstract DirectoryProperty getResultPath();
+	@Incremental
+	@OutputFiles
+	protected abstract ConfigurableFileCollection getOutputFiles();
 
-	@Input
-	@Optional
-	public abstract Property<String> getFormat();
+	protected void calculateInputOutputFiles() throws IOException {
+		if (null != queryPath && null != resultPath && null != format) {
+			final List<File> inputFiles = new ArrayList<>();
+			final List<File> outputFiles = new ArrayList<>();
+			if (queryPath.isFile()) {
+				inputFiles.add(queryPath);
+			} else {
+				// See https://docs.oracle.com/javase/8/docs/api/java/nio/file/DirectoryStream.html
+				try (DirectoryStream<Path> stream = Files.newDirectoryStream(queryPath.toPath(), "*.sparql")) {
+					for (Path entry : stream) {
+						inputFiles.add(entry.toFile());
+					}
+				} catch (DirectoryIteratorException ex) {
+					throw new GradleException(ex.getMessage(), ex.getCause());
+				}
+			}
+			getInputFiles().setFrom(inputFiles);
+			Path outputFolder = resultPath.toPath();
+			inputFiles.forEach(f -> {
+				String ifn = f.getName();
+				String ofn = ifn.substring(0, ifn.length() - 6) + format;
+				outputFiles.add(outputFolder.resolve(ofn).toFile());
+			});
+			getOutputFiles().setFrom(outputFiles);
+		}
+	}
+
 
 	@Input
 	@Optional
@@ -87,13 +108,13 @@ public abstract class OwlQueryTask extends DefaultTask {
 			args.add("-q");
 			args.add(queryPath.getAbsolutePath());
 		}
-		if (getResultPath().isPresent()) {
+		if (null != resultPath) {
 			args.add("-r");
-			args.add(getResultPath().get().getAsFile().getAbsolutePath());
+			args.add(resultPath.getAbsolutePath());
 		}
-		if (getFormat().isPresent()) {
+		if (null != format) {
 			args.add("-f");
-			args.add(getFormat().get());
+			args.add(format);
 		}
 		if (getDebug().isPresent() && getDebug().get()) {
 			args.add("-d");

--- a/owl-query/src/main/java/io/opencaesar/owl/query/OwlQueryApp.java
+++ b/owl-query/src/main/java/io/opencaesar/owl/query/OwlQueryApp.java
@@ -49,7 +49,9 @@ import com.beust.jcommander.Parameter;
 import com.beust.jcommander.ParameterException;
 
 public class OwlQueryApp {
-	
+
+	public static String DEFAULT_FORMAT = "xml";
+
 	@Parameter(
 		names = {"--endpoint-url", "-e"},
 		description = "Sparql Endpoint URL (Required)",
@@ -78,7 +80,7 @@ public class OwlQueryApp {
 		description = "Format of the results. Default is xml. Options: xml, json, csv, n3, ttl, n-triple or tsv (Optional)",
 		validateWith = FormatType.class,
 		order = 4)
-	private String format = "xml";
+	private String format = DEFAULT_FORMAT;
 
 	@Parameter(
 		names = {"--debug", "-d"},

--- a/owl-shacl-fuseki-gradle/src/main/java/io/opencaesar/owl/shacl/fuseki/OwlShaclFusekiTask.java
+++ b/owl-shacl-fuseki-gradle/src/main/java/io/opencaesar/owl/shacl/fuseki/OwlShaclFusekiTask.java
@@ -73,7 +73,8 @@ public abstract class OwlShaclFusekiTask extends DefaultTask {
 			Path outputFolder = resultPath.toPath();
 			inputFiles.forEach(f -> {
 				String ifn = f.getName();
-				String ofn = ifn.substring(0, ifn.length() - 5) + OwlShaclFusekiApp.OUTPUT_FORMAT;
+				int i = ifn.lastIndexOf('.');
+				String ofn = ((i> 0) ? ifn.substring(0, i+1) : ifn+'.') + OwlShaclFusekiApp.OUTPUT_FORMAT;
 				outputFiles.add(outputFolder.resolve(ofn).toFile());
 			});
 			getOutputFiles().setFrom(outputFiles);

--- a/owl-shacl-fuseki-gradle/src/main/java/io/opencaesar/owl/shacl/fuseki/OwlShaclFusekiTask.java
+++ b/owl-shacl-fuseki-gradle/src/main/java/io/opencaesar/owl/shacl/fuseki/OwlShaclFusekiTask.java
@@ -14,6 +14,7 @@ import org.apache.log4j.xml.DOMConfigurator;
 import org.gradle.api.DefaultTask;
 import org.gradle.api.GradleException;
 import org.gradle.api.file.ConfigurableFileCollection;
+import org.gradle.api.file.DirectoryProperty;
 import org.gradle.api.file.RegularFileProperty;
 import org.gradle.api.provider.Property;
 import org.gradle.api.tasks.Input;
@@ -62,7 +63,7 @@ public abstract class OwlShaclFusekiTask extends DefaultTask {
 	protected abstract ConfigurableFileCollection getInputFiles();
 
 	@OutputDirectory
-	public abstract RegularFileProperty getResultPath();
+	public abstract DirectoryProperty getResultPath();
 
 	@Input
 	@Optional

--- a/owl-shacl-fuseki-gradle/src/main/java/io/opencaesar/owl/shacl/fuseki/OwlShaclFusekiTask.java
+++ b/owl-shacl-fuseki-gradle/src/main/java/io/opencaesar/owl/shacl/fuseki/OwlShaclFusekiTask.java
@@ -38,7 +38,6 @@ public abstract class OwlShaclFusekiTask extends DefaultTask {
     // contributes to the input files
 	public File queryPath;
 
-	@SuppressWarnings({ "unused", "deprecation" })
 	public void setQueryPath(File path) throws IOException {
 		queryPath = path;
 		final List<File> files = new ArrayList<>();

--- a/owl-shacl-fuseki-gradle/src/main/java/io/opencaesar/owl/shacl/fuseki/OwlShaclFusekiTask.java
+++ b/owl-shacl-fuseki-gradle/src/main/java/io/opencaesar/owl/shacl/fuseki/OwlShaclFusekiTask.java
@@ -9,60 +9,76 @@ import java.nio.file.Path;
 import java.util.ArrayList;
 import java.util.List;
 
-import org.apache.log4j.Logger;
-import org.apache.log4j.xml.DOMConfigurator;
 import org.gradle.api.DefaultTask;
 import org.gradle.api.GradleException;
+import org.gradle.api.ProjectConfigurationException;
 import org.gradle.api.file.ConfigurableFileCollection;
-import org.gradle.api.file.DirectoryProperty;
-import org.gradle.api.file.RegularFileProperty;
 import org.gradle.api.provider.Property;
-import org.gradle.api.tasks.Input;
-import org.gradle.api.tasks.InputFiles;
-import org.gradle.api.tasks.Optional;
-import org.gradle.api.tasks.OutputDirectory;
-import org.gradle.api.tasks.TaskAction;
+import org.gradle.api.tasks.*;
 import org.gradle.work.Incremental;
 
 public abstract class OwlShaclFusekiTask extends DefaultTask {
 
-	private final static Logger LOGGER = Logger.getLogger(OwlShaclFusekiTask.class);
-
-	static {
-		DOMConfigurator.configure(ClassLoader.getSystemClassLoader().getResource("owlshacl.log4j2.properties"));
-	}
-
 	@Input
 	public abstract Property<String> getEndpointURL();
 
-    // contributes to the input files
-	public File queryPath;
+	private File queryPath;
 
-	public void setQueryPath(File path) throws IOException {
+	@Input
+	public File getQueryPath() { return queryPath; }
+
+	public void setQueryPath(File path) {
 		queryPath = path;
-		final List<File> files = new ArrayList<>();
-		if (null == queryPath || !queryPath.exists() || !queryPath.canRead())
-			LOGGER.warn("OwlShacl("+getName()+"): queryPath is not an existing, readable input file or directory got: " + path);
-		else if (queryPath.isFile())
-			files.add(queryPath);
-		else
-			// See https://docs.oracle.com/javase/8/docs/api/java/nio/file/DirectoryStream.html
-			try (DirectoryStream<Path> stream = Files.newDirectoryStream(path.toPath(), "*.shacl")) {
-				for (Path entry : stream) {
-					files.add(entry.toFile());
-				}
-			} catch (DirectoryIteratorException ex) {
-				throw ex.getCause();
-			}
-		getInputFiles().setFrom(files);
+		calculateInputOutputFiles();
+	}
+
+	private File resultPath;
+
+	@Internal
+	public File getResultPath() { return resultPath; }
+
+	@SuppressWarnings("unused")
+	public void setResultPath(File p) {
+		resultPath = p;
+		calculateInputOutputFiles();
 	}
 
 	@Incremental
 	@InputFiles
 	protected abstract ConfigurableFileCollection getInputFiles();
 
-	@OutputDirectory
-	public abstract DirectoryProperty getResultPath();
+	@Incremental
+	@OutputFiles
+	protected abstract ConfigurableFileCollection getOutputFiles();
+
+	protected void calculateInputOutputFiles() {
+		if (null != queryPath && null != resultPath) {
+			final List<File> inputFiles = new ArrayList<>();
+			final List<File> outputFiles = new ArrayList<>();
+			if (queryPath.isFile()) {
+				inputFiles.add(queryPath);
+			} else {
+				// See https://docs.oracle.com/javase/8/docs/api/java/nio/file/DirectoryStream.html
+				try (DirectoryStream<Path> stream = Files.newDirectoryStream(queryPath.toPath(), "*.shacl")) {
+					for (Path entry : stream) {
+						inputFiles.add(entry.toFile());
+					}
+				} catch (DirectoryIteratorException ex) {
+					throw new ProjectConfigurationException(ex.getCause().getMessage(), ex.getCause());
+				} catch (IOException e) {
+					throw new ProjectConfigurationException(e.getMessage(), e);
+				}
+			}
+			getInputFiles().setFrom(inputFiles);
+			Path outputFolder = resultPath.toPath();
+			inputFiles.forEach(f -> {
+				String ifn = f.getName();
+				String ofn = ifn.substring(0, ifn.length() - 5) + OwlShaclFusekiApp.OUTPUT_FORMAT;
+				outputFiles.add(outputFolder.resolve(ofn).toFile());
+			});
+			getOutputFiles().setFrom(outputFiles);
+		}
+	}
 
 	@Input
 	@Optional
@@ -79,9 +95,9 @@ public abstract class OwlShaclFusekiTask extends DefaultTask {
 			args.add("-q");
 			args.add(queryPath.getAbsolutePath());
 		}
-		if (getResultPath().isPresent()) {
+		if (null != resultPath) {
 			args.add("-r");
-			args.add(getResultPath().get().getAsFile().getAbsolutePath());
+			args.add(resultPath.getAbsolutePath());
 		}
 		if (getDebug().isPresent() && getDebug().get()) {
 			args.add("-d");

--- a/owl-shacl-fuseki/src/main/java/io/opencaesar/owl/shacl/fuseki/OwlShaclFusekiApp.java
+++ b/owl-shacl-fuseki/src/main/java/io/opencaesar/owl/shacl/fuseki/OwlShaclFusekiApp.java
@@ -171,6 +171,8 @@ public class OwlShaclFusekiApp {
     	return (version != null) ? version : "<SNAPSHOT>";
     }
 
+	public static String OUTPUT_FORMAT = "ttl";
+
 	/**
 	 * Executes a given query and outputs the result to result/outputName.frame
 	 * 
@@ -193,7 +195,7 @@ public class OwlShaclFusekiApp {
 				RDFParser.create().fromString(response.body()).lang(RDFLanguages.TURTLE).build().parse(model);
 				LOGGER.info("Finished parsing result: " + model);
 	
-				File output = new File(resultPath + File.separator + outputName + ".ttl");
+				File output = new File(resultPath + File.separator + outputName + "." + OUTPUT_FORMAT);
 	
 				if (output.exists()) {
 					output.delete();


### PR DESCRIPTION
Fixes #29 

There could be an improvement for this example:

```
task owlShacl(type:io.opencaesar.owl.shacl.fuseki.OwlShaclFusekiTask, dependsOn: owlLoad, group: 'oml') {
	endpointURL = "http://localhost:3030/$fusekiDataset"
	queryPath = file('src/shacl')
	resultPath = file('build/reports')
}
```

If the `queryPath` does not exists, we get no error message:

```
 .\gradlew

> Configure project :

FAILURE: Build failed with an exception.

* Where:
Build file 'C:\opt\local\github.imce-demos\msr-fse-demo1\build.gradle' line: 400

* What went wrong:
A problem occurred evaluating root project 'msr-fse-demo1'.
> C:\opt\local\github.imce-demos\msr-fse-demo1\src\shacl
   > C:\opt\local\github.imce-demos\msr-fse-demo1\src\shacl

* Try:
Run with --stacktrace option to get the stack trace. Run with --info or --debug option to get more log output. Run with --scan to get full insights.
```

With `--stacktrace`, we find that the exception comes from this code:

```
	protected void calculateInputOutputFiles() {
		if (null != queryPath && null != resultPath) {
			final List<File> inputFiles = new ArrayList<>();
			final List<File> outputFiles = new ArrayList<>();
			if (queryPath.isFile()) {
				inputFiles.add(queryPath);
			} else {
				// See https://docs.oracle.com/javase/8/docs/api/java/nio/file/DirectoryStream.html
				try (DirectoryStream<Path> stream = Files.newDirectoryStream(queryPath.toPath(), "*.shacl")) {
					for (Path entry : stream) {
						inputFiles.add(entry.toFile());
					}
				} catch (DirectoryIteratorException ex) {
					throw new ProjectConfigurationException(ex.getCause().getMessage(), ex.getCause());
				} catch (IOException e) {
					throw new ProjectConfigurationException(e.getMessage(), e); // here
				}
			}
...
```

Tried to throw `GradleException` -- still no message.
